### PR TITLE
refactor: update references to prior repo 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool
     ####   /go/src/bitbucket.org/circleci/go-tool
-    working_directory: /go/src/github.com/rakyll/go-sql-driver-spanner
+    working_directory: /go/src/github.com/cloudspannerecosystem/go-sql-spanner
     steps:
       - checkout
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# go-sql-driver-spanner
+# go-sql-spanner
 
-[![CircleCI](https://circleci.com/gh/rakyll/go-sql-driver-spanner.svg?style=svg)](https://circleci.com/gh/rakyll/go-sql-driver-spanner) [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/rakyll/go-sql-driver-spanner)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/cloudspannerecosystem/go-sql-spanner)
 
 [Google Cloud Spanner](https://cloud.google.com/spanner) driver for
 Go's [database/sql](https://golang.org/pkg/database/sql/) package.
@@ -9,7 +9,7 @@ Go's [database/sql](https://golang.org/pkg/database/sql/) package.
 THIS IS A WORK-IN-PROGRESS, DON'T USE IT IN PRODUCTION YET.
 
 ``` go
-import _ "github.com/rakyll/go-sql-driver-spanner"
+import _ "github.com/cloudspannerecosystem/go-sql-spanner"
 
 db, err := sql.Open("spanner", "projects/PROJECT/instances/INSTANCE/databases/DATABASE")
 if err != nil {

--- a/driver.go
+++ b/driver.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner"
-	"github.com/rakyll/go-sql-driver-spanner/internal"
+	"github.com/cloudspannerecosystem/go-sql-spanner/internal"
 	"google.golang.org/api/option"
 )
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -18,7 +18,7 @@ import (
 	"database/sql"
 	"log"
 
-	spannerdriver "github.com/rakyll/go-sql-driver-spanner"
+	spannerdriver "github.com/cloudspannerecosystem/go-sql-spanner"
 	"google.golang.org/api/option"
 )
 

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/rakyll/go-sql-driver-spanner"
+	_ "github.com/cloudspannerecosystem/go-sql-spanner"
 )
 
 func main() {

--- a/examples/transactions/main.go
+++ b/examples/transactions/main.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/rakyll/go-sql-driver-spanner"
+	_ "github.com/cloudspannerecosystem/go-sql-spanner"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rakyll/go-sql-driver-spanner
+module github.com/cloudspannerecosystem/go-sql-spanner
 
 go 1.14
 

--- a/stmt.go
+++ b/stmt.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 
 	"cloud.google.com/go/spanner"
-	"github.com/rakyll/go-sql-driver-spanner/internal"
+	"github.com/cloudspannerecosystem/go-sql-spanner/internal"
 )
 
 type stmt struct {

--- a/tx.go
+++ b/tx.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"cloud.google.com/go/spanner"
-	"github.com/rakyll/go-sql-driver-spanner/internal"
+	"github.com/cloudspannerecosystem/go-sql-spanner/internal"
 )
 
 type roTx struct {


### PR DESCRIPTION
The linked documentation and internal imports still reference the prior repo `rakyll/go-sql-driver-spanner`. This PR updates all references to the previous repo to use the current repo.