### PR TITLE
build: skip integration tests on PROD for PRs from forks

### DIFF
--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -5,7 +5,20 @@ on:
     branches: [ main ]
 name: Integration tests on production
 jobs:
+  check-env:
+    outputs:
+      has-key: ${{ steps.project-id.outputs.defined }}
+    runs-on: ubuntu-latest
+    steps:
+    - id: project-id
+      env:
+        GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      if: "${{ env.GCP_PROJECT_ID != '' }}"
+      run: echo "::set-output name=defined::true"
+
   test:
+    needs: [check-env]
+    if: needs.check-env.outputs.has-key == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Install Go


### PR DESCRIPTION
Skip integration tests on production for PRs that do not have access to the
GitHub secrets. This basically means all PRs that are created from forks.

The integration tests are still executed on the emulator, and they are executed
on production when the PR is merged with main.