### PR TITLE
build: run go test with higher timeout

### DIFF
--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -35,7 +35,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: Run integration tests on production
-        run: go test
+        run: go test -timeout 30m
         env:
           JOB_TYPE: test
           SPANNER_TEST_PROJECT: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Increases the timeout of the `go test` command itself to 30 minutes, as the default timeout for tests in Go is 10 minutes (https://pkg.go.dev/cmd/go#hdr-Testing_flags)