### PR TITLE
fix: race condition when opening multiple connections in parallel as first action

### DIFF
--- a/.github/workflows/integration-tests-on-production.yml
+++ b/.github/workflows/integration-tests-on-production.yml
@@ -20,7 +20,7 @@ jobs:
     needs: [check-env]
     if: needs.check-env.outputs.has-key == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -35,7 +35,7 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: Run integration tests on production
-        run: go test -timeout 30m
+        run: go test -timeout 45m
         env:
           JOB_TYPE: test
           SPANNER_TEST_PROJECT: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
Fixes a potential race condition when the first action that a client application takes
is to open multiple connections in parallel. Each of these connections will try to compile
the client side statements the first time a statement is executed, but only one of them
should be allowed to do so. The rest should wait for the compilation to finish.

Also adds session configuration options to the connection string and caching of Spanner
clients that use the exact same connection string.

Fixes #58