### PR TITLE
test: use sql.NullString instead of spanner.NullString

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1672,8 +1672,7 @@ func TestAllTypes(t *testing.T) {
 			name: "Null* struct values",
 			key:  4,
 			input: []interface{}{
-				// TODO: Fix the requirement to use spanner.NullString here.
-				4, sql.NullBool{}, spanner.NullString{}, []byte(nil), sql.NullInt64{}, sql.NullFloat64{},
+				4, sql.NullBool{}, sql.NullString{}, []byte(nil), sql.NullInt64{}, sql.NullFloat64{},
 				spanner.NullNumeric{}, spanner.NullDate{}, sql.NullTime{}, nullJsonOrString(false, ""),
 				[]spanner.NullBool(nil),
 				[]spanner.NullString(nil),


### PR DESCRIPTION
Fixes a minor TODO in the integration test.